### PR TITLE
PR: Enhance next launch description text and fix errors, and update Falcon Heavy "real" launch date

### DIFF
--- a/app/helpers/nextLaunches.js
+++ b/app/helpers/nextLaunches.js
@@ -19,12 +19,12 @@ const nextLaunches = (upcomingLaunches) => {
   let payloadDesc = '';
   if (launch.rocket.second_stage.payloads[0].payload_type.indexOf('Dragon') !== -1) {
     payloadDesc = `A SpaceX Dragon capsule will launch into LEO atop a
-                    ${launch.rocket.rocket_name} rocket from
-                    ${launch.launch_site.site_name_long}, carrying
-                    ${payloadMass} kg of supplies and scientific cargo to the
-                    International Space Station.`;
+                  ${launch.rocket.rocket_name} rocket from
+                  ${launch.launch_site.site_name_long}, carrying
+                  ${payloadMass} kg of supplies and scientific cargo to the
+                  International Space Station.`;
   } else {
-  payloadDesc = `A SpaceX ${launch.rocket.rocket_name} rocket will launch from
+    payloadDesc = `A SpaceX ${launch.rocket.rocket_name} rocket will launch from
                   ${launch.launch_site.site_name_long},
                   lofting the ${payloadMass > 0 ? `${payloadMass} kg ` : ''}
                   satellite${launch.rocket.second_stage.payloads.length > 1 ? 's ' : ' '}

--- a/app/helpers/nextLaunches.js
+++ b/app/helpers/nextLaunches.js
@@ -18,13 +18,17 @@ const nextLaunches = (upcomingLaunches) => {
 
   let payloadDesc = '';
   if (launch.rocket.second_stage.payloads[0].payload_type.indexOf('Dragon') !== -1) {
-    payloadDesc = `SpaceX will launch a Dragon capsule to LEO, bringing
-                  ${payloadMass}kg of supplies and scientific cargo to the ISS.`;
+    payloadDesc = `A SpaceX Dragon capsule will launch into LEO atop a
+                    ${launch.rocket.rocket_name} rocket from
+                    ${launch.launch_site.site_name_long}, carrying
+                    ${payloadMass} kg of supplies and scientific cargo to the
+                    International Space Station.`;
   } else {
-    payloadDesc = `SpaceX will launch
-                  the${payloadMass > 0 ? `${payloadMass}kg` : ''} communication
+  payloadDesc = `A SpaceX ${launch.rocket.rocket_name} rocket will launch from
+                  ${launch.launch_site.site_name_long},
+                  lofting the ${payloadMass > 0 ? `${payloadMass} kg ` : ''}
                   satellite${launch.rocket.second_stage.payloads.length > 1 ? 's ' : ' '}
-                  ${payloadName} into a ${launch.rocket.second_stage.payloads[0].orbit} trajectory.`;
+                  ${payloadName} to a ${launch.rocket.second_stage.payloads[0].orbit} trajectory.`;
   }
 
   payloadDesc += ' ';

--- a/app/helpers/timelines.js
+++ b/app/helpers/timelines.js
@@ -1,9 +1,9 @@
-const sixWeeks = 6 * 7 * 24 * 3600;
+const sixDays = 6 * 24 * 3600;
 
 const timelines = () => ({
   elonMuskBet: (new Date('2026-01-01').getTime() / 1000),
   foundingDate: (new Date('2002-03-14').getTime() / 1000),
-  falconHeavyLaunchDate: ((new Date().getTime() / 1000) + sixWeeks),
+  falconHeavyLaunchDate: ((new Date().getTime() / 1000) + sixDays),
 });
 
 export default timelines;


### PR DESCRIPTION
I noticed some text spacing bugs in the GovSat-1 launch text, and some inaccuracies in the current FH one, so I prepped a PR to hopefully fix that, as well as update FH's "real" (as in fake, but as in actually we all know for real) launch date (hah). While I was added, I refined the prose and added a few additional elements, most notably the name of the rocket being launched (F9 or FH), and the launch site.

Please be aware I have close to zero JS experience and no ability to easily test this on my system, so the modifications are basically "blind". Hopefully your CIs can catch any errors, or you could build in on your dev machine to check. Sorry about that, and thanks for considering!