### PR TITLE
Fix next launch display timezone information

### DIFF
--- a/app/components/ContentBlock.js
+++ b/app/components/ContentBlock.js
@@ -135,7 +135,7 @@ class ContentBlock extends Component {
     let ribbonText = null;
 
     if (stat.tabTitle === 'Next Launch' && dataset !== null) {
-      ribbonText = format(fromUnix(stat.data), 'MMM Do, h:mm:ssa (UTC)');
+      ribbonText = format(fromUnix(stat.data), 'MMM Do, h:mm:ssa (UTCZ)');
     }
 
     const background = stat.background ? stat.background : backgroundImage;


### PR DESCRIPTION
Fix #47 .

It should display like `JUN 11TH, 8:00:00AM (UTC+08:00)` so that user know the launch time in user's timezone.